### PR TITLE
Feature/listen to blob added event when optional

### DIFF
--- a/src/NexxLogic.BlobConfiguration.AspNetCore/FileProvider/BlobFileProvider.cs
+++ b/src/NexxLogic.BlobConfiguration.AspNetCore/FileProvider/BlobFileProvider.cs
@@ -107,7 +107,22 @@ public class BlobFileProvider : IFileProvider
                 if (!_exists)
                 {
                     _logger.LogWarning("file does not exist");
-                    break;
+
+                    if (_blobConfig.Optional)
+                    {
+                        _logger.LogInformation("Checking if optional file is added to blob container since last scan");
+
+                        var doesItExistNow = blobClient.Exists(cancellationToken: token);
+                        if (doesItExistNow)
+                        {
+                            RaiseChanged();
+                        }
+                        continue;
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
 
                 var properties = await blobClient.GetPropertiesAsync(cancellationToken: token);

--- a/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/Factories/BlobClientFactoryTests.cs
+++ b/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/Factories/BlobClientFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Storage.Blobs;
 using NexxLogic.BlobConfiguration.AspNetCore.Factories;
 using NexxLogic.BlobConfiguration.AspNetCore.Options;
+using NSubstitute;
 
 namespace NexxLogic.BlobConfiguration.AspNetCore.Tests.Factories;
 
@@ -12,19 +13,28 @@ public class BlobClientFactoryTests
         // Arrange
         var blobName = "settings.json";
         var blobContainerName = "config";
-        var blobContainerFactory = new Mock<IBlobContainerClientFactory>();
+        var blobContainerFactory = Substitute.For<IBlobContainerClientFactory>();
 
-        var blobClient = new Mock<BlobClient>();
-        blobClient.SetupGet(x => x.BlobContainerName).Returns(blobContainerName);
-        blobClient.SetupGet(x => x.Name).Returns(blobName);
+        var blobClient = Substitute.For<BlobClient>();
+        blobClient
+            .BlobContainerName
+            .Returns(blobContainerName);
 
-        var blobContainerClient = new Mock<BlobContainerClient>();
-        blobContainerClient.SetupGet(x => x.Name).Returns(blobContainerName);
-        blobContainerClient.Setup(x => x.GetBlobClient(blobName)).Returns(blobClient.Object);
-        blobContainerFactory.Setup(x => x.GetBlobContainerClient())
-            .Returns(blobContainerClient.Object);
+        blobClient
+            .Name
+            .Returns(blobName);
 
-        var sut = new BlobClientFactory(blobContainerFactory.Object);
+        var blobContainerClient = Substitute.For<BlobContainerClient>();
+        blobContainerClient.Name.Returns(blobContainerName);
+        blobContainerClient
+            .GetBlobClient(blobName)
+            .Returns(blobClient);
+
+        blobContainerFactory
+            .GetBlobContainerClient()
+            .Returns(blobContainerClient);
+
+        var sut = new BlobClientFactory(blobContainerFactory);
 
         // Act
         var result = sut.GetBlobClient(blobName);

--- a/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
+++ b/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
@@ -7,64 +7,28 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NexxLogic.BlobConfiguration.AspNetCore.Factories;
 using NexxLogic.BlobConfiguration.AspNetCore.FileProvider;
 using NexxLogic.BlobConfiguration.AspNetCore.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace NexxLogic.BlobConfiguration.AspNetCore.Tests.FileProvider;
 
 public class BlobFileProviderTests
-{
-    private readonly BlobFileProvider _sut;
-
-    private readonly Mock<BlobClient> _blobClientMock = new();
-
-    private readonly Mock<BlobContainerClient> _blobContainerClientMock = new();
-
-
-    private readonly BlobConfigurationOptions _blobConfig;
+{   
     private const string BLOB_NAME = "settings.json";
     private const int DEFAULT_CONTENT_LENGTH = 123;
-    private readonly DateTimeOffset _defaultLastModified = new(2022, 12, 19, 1, 1, 1, default);
-
-    public BlobFileProviderTests()
-    {
-        var blobProperties = BlobsModelFactory.BlobProperties(
-            lastModified: _defaultLastModified,
-            contentLength: DEFAULT_CONTENT_LENGTH
-        );
-        _blobClientMock
-            .Setup(_ => _.GetProperties(default, default))
-            .Returns(Response.FromValue(blobProperties, Mock.Of<Response>()));
-
-        var blobClientFactoryMock = new Mock<IBlobClientFactory>();
-        blobClientFactoryMock
-            .Setup(_ => _.GetBlobClient(BLOB_NAME))
-            .Returns(_blobClientMock.Object);
-
-        var blobContainerClientFactoryMock = new Mock<IBlobContainerClientFactory>();
-        blobContainerClientFactoryMock
-            .Setup(_ => _.GetBlobContainerClient())
-            .Returns(_blobContainerClientMock.Object);
-
-        _blobConfig = new BlobConfigurationOptions
-        {
-            ReloadInterval = 1
-        };
-
-        var loggerFactory = new NullLoggerFactory();
-        var logger = loggerFactory.CreateLogger<BlobFileProvider>();
-
-        _sut = new BlobFileProvider(blobClientFactoryMock.Object, blobContainerClientFactoryMock.Object, _blobConfig, logger);
-    }
+    private static readonly DateTimeOffset _defaultLastModified = new(2022, 12, 19, 1, 1, 1, default);      
 
     [Fact]
     public void GetFileInfo_ShouldReturnCorrectFileInfo_WhenBlobExists()
     {
         // Arrange
-        _blobClientMock
-            .SetupGet(_ => _.Name)
+        var sut = CreateSut(out var blobClientMock);
+        blobClientMock
+            .Name
             .Returns(BLOB_NAME);
 
         // Act
-        var result = _sut.GetFileInfo(BLOB_NAME);
+        var result = sut.GetFileInfo(BLOB_NAME);
 
         // Assert
         result.Exists.Should().BeTrue();
@@ -77,8 +41,9 @@ public class BlobFileProviderTests
     public void GetFileInfo_ShouldReturnCorrectFileInfo_WhenBlobDoesNotExist()
     {
         // Arrange
-        _blobClientMock
-            .Setup(_ => _.GetProperties(default, default))
+        var sut = CreateSut(out var blobClientMock);
+        blobClientMock
+            .GetProperties(default, default)
             .Throws(new RequestFailedException(
                 (int)HttpStatusCode.NotFound,
                 "Blob not found",
@@ -87,7 +52,7 @@ public class BlobFileProviderTests
             ));
 
         // Act
-        var result = _sut.GetFileInfo(BLOB_NAME);
+        var result = sut.GetFileInfo(BLOB_NAME);
 
         // Assert
         result.Exists.Should().BeFalse();
@@ -98,19 +63,21 @@ public class BlobFileProviderTests
     public async Task Watch_ShouldRaiseChange_WhenNewVersionIsAvailable()
     {
         // Arrange
-        _sut.GetFileInfo(BLOB_NAME);
+        var sut = CreateSut(out var blobClientMock);
+        sut.GetFileInfo(BLOB_NAME);
 
         var blobProperties = BlobsModelFactory.BlobProperties(
             lastModified: _defaultLastModified.Add(TimeSpan.FromSeconds(30)),
             contentLength: DEFAULT_CONTENT_LENGTH
         );
-        _blobClientMock
-            .Setup(_ => _.GetPropertiesAsync(null, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Response.FromValue(blobProperties, Mock.Of<Response>()));
+
+        var changeToken = (BlobChangeToken)sut.Watch(BLOB_NAME);
+        blobClientMock
+            .GetPropertiesAsync(null, changeToken.CancellationToken)
+            .Returns(Response.FromValue(blobProperties, Substitute.For<Response>()));
 
         // Act
-        var changeToken = _sut.Watch(BLOB_NAME);
-        await Task.Delay(20);
+        await Task.Delay(30);
 
         // Assert
         changeToken.HasChanged.Should().BeTrue();
@@ -120,51 +87,165 @@ public class BlobFileProviderTests
     public async Task Watch_ShouldNotRetrieveProperties_WhenLoadIsPending()
     {
         // Act
-        var changeToken = (BlobChangeToken)_sut.Watch(BLOB_NAME);
+        var sut = CreateSut(out var blobClientMock);
+        var changeToken = (BlobChangeToken)sut.Watch(BLOB_NAME);
         await Task.Delay(20);
 
         // Assert
-        _blobClientMock
-            .Verify(_ => _.GetPropertiesAsync(null, changeToken.CancellationToken), Times.Never);
+        await blobClientMock
+              .DidNotReceive()
+              .GetPropertiesAsync(null, changeToken.CancellationToken);
     }
 
     [Fact]
     public async Task Watch_ShouldReturn_WhenCancellationIsRequested()
     {
         // Arrange
-        _sut.GetFileInfo(BLOB_NAME);
-        _blobConfig.ReloadInterval = 100_000;
+        var options = new BlobConfigurationOptions
+        {
+            ReloadInterval = 100_000
+        };
+        var sut = CreateSut(out var blobClientMock, options);
+        sut.GetFileInfo(BLOB_NAME);        
 
         // Act
-        var changeToken = (BlobChangeToken)_sut.Watch(BLOB_NAME);
+        var changeToken = (BlobChangeToken)sut.Watch(BLOB_NAME);
         await Task.Delay(10);
         changeToken.OnReload();
 
         // Assert
-        _blobClientMock
-            .Verify(_ => _.GetPropertiesAsync(null, changeToken.CancellationToken), Times.Never);
+        await blobClientMock
+           .DidNotReceive()
+           .GetPropertiesAsync(null, changeToken.CancellationToken);
     }
 
     [Fact]
-    public async Task Watch_ShouldStopRunning_WhenBlobDoesNotExist()
+    public async Task When_BlobFile_Not_Optional_And_BlobDoesNotExist_Watch_ShouldStopRunning()
     {
-        // Arrange
-        _blobClientMock
-            .Setup(_ => _.GetProperties(default, default))
+        // Arrange        
+        var sut = CreateSut(out var blobClientMock);
+        blobClientMock
+            .GetProperties(default, default)
             .Throws(new RequestFailedException(
                 (int)HttpStatusCode.NotFound,
                 "Blob not found",
                 BlobErrorCode.BlobNotFound.ToString(),
                 null
             ));
-        _sut.GetFileInfo(BLOB_NAME);
+        sut.GetFileInfo(BLOB_NAME);
 
         // Act
-        var changeToken = (BlobChangeToken)_sut.Watch(BLOB_NAME);
+        var changeToken = (BlobChangeToken)sut.Watch(BLOB_NAME);
         await Task.Delay(20);
 
         // Assert
-        _blobClientMock
-            .Verify(_ => _.GetPropertiesAsync(null, changeToken.CancellationToken), Times.Never);
+        await blobClientMock
+            .DidNotReceive()
+            .GetPropertiesAsync(null, changeToken.CancellationToken);
+    }
+
+    [Fact]
+    public async Task When_BlobFile_Optional_And_BlobDoesNotExist_Watch_Should_Keep_Checking_For_Existence()
+    {
+        // Arrange        
+        var options = new BlobConfigurationOptions
+        {            
+            ReloadInterval = 1,
+            Optional = true
+        };
+        var sut = CreateSut(out var blobClientMock, options);
+
+        blobClientMock
+            .GetProperties(default, default)
+            .Throws(new RequestFailedException(
+                (int)HttpStatusCode.NotFound,
+                "Blob not found",
+                BlobErrorCode.BlobNotFound.ToString(),
+                null
+            ));
+        sut.GetFileInfo(BLOB_NAME);
+
+        // Act
+        var changeToken = (BlobChangeToken)sut.Watch(BLOB_NAME);
+        await Task.Delay(30);
+
+        // Assert
+        blobClientMock
+            .Received()
+            .Exists(changeToken.CancellationToken);
+    }
+
+    [Fact]
+    public async Task When_BlobFile_Optional_And_File_Added_Later_Then_RaisesChange()
+    {
+        // Arrange        
+        var options = new BlobConfigurationOptions
+        {
+            ReloadInterval = 1,
+            Optional = true
+        };
+        var sut = CreateSut(out var blobClientMock, options);
+
+        blobClientMock
+            .GetProperties(default, default)
+            .Throws(new RequestFailedException(
+                (int)HttpStatusCode.NotFound,
+                "Blob not found",
+                BlobErrorCode.BlobNotFound.ToString(),
+                null
+            ));
+        sut.GetFileInfo(BLOB_NAME);
+        
+        var changeToken = (BlobChangeToken)sut.Watch(BLOB_NAME);
+        await Task.Delay(20);
+
+        // Pre-Assert
+        blobClientMock
+            .Received()
+            .Exists(changeToken.CancellationToken);
+        changeToken.HasChanged.Should().BeFalse();
+
+        // Act
+        blobClientMock            
+            .Exists(changeToken.CancellationToken)
+            .Returns(Response.FromValue(true, Substitute.For<Response>()));
+        await Task.Delay(30); // making sure that exists method returns with a TRUE value
+
+        // Assert
+        changeToken.HasChanged.Should().BeTrue();
+    }
+
+    static BlobFileProvider CreateSut(out BlobClient blobClientMock, BlobConfigurationOptions? options = null)
+    {
+        var blobProperties = BlobsModelFactory.BlobProperties(
+            lastModified: _defaultLastModified,
+            contentLength: DEFAULT_CONTENT_LENGTH
+        );
+
+        blobClientMock = Substitute.For<BlobClient>();
+        blobClientMock
+            .GetProperties(default, default)
+            .Returns(Response.FromValue(blobProperties, Substitute.For<Response>()));
+
+        var blobClientFactoryMock = Substitute.For<IBlobClientFactory>();
+        blobClientFactoryMock
+            .GetBlobClient(BLOB_NAME)
+            .Returns(blobClientMock);
+
+        var blobContainerClientMock = Substitute.For<BlobContainerClient>();
+        var blobContainerClientFactoryMock = Substitute.For<IBlobContainerClientFactory>();
+        blobContainerClientFactoryMock
+            .GetBlobContainerClient()
+            .Returns(blobContainerClientMock);
+
+        var defaultBlobConfig = new BlobConfigurationOptions
+        {
+            ReloadInterval = 1
+        };
+
+        var loggerFactory = new NullLoggerFactory();
+        var logger = loggerFactory.CreateLogger<BlobFileProvider>();
+
+        return new BlobFileProvider(blobClientFactoryMock, blobContainerClientFactoryMock, options ?? defaultBlobConfig, logger);
     }
 }

--- a/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
+++ b/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
@@ -167,12 +167,14 @@ public class BlobFileProviderTests
 
         // Act
         var changeToken = (BlobChangeToken)sut.Watch(BLOB_NAME);
-        await Task.Delay(30);
+        await Task.Delay(100);
 
         // Assert
-        blobClientMock
-            .Received()
-            .Exists(changeToken.CancellationToken);
+        var existCalls = blobClientMock.ReceivedCalls().Where(x =>
+        {
+            return x.GetMethodInfo().Name == nameof(BlobClient.Exists);
+        });
+        Assert.True(existCalls.Count() > 1);
     }
 
     [Fact]

--- a/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/NexxLogic.BlobConfiguration.AspNetCore.Tests.csproj
+++ b/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/NexxLogic.BlobConfiguration.AspNetCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />    
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/Usings.cs
+++ b/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/Usings.cs
@@ -1,3 +1,2 @@
 global using FluentAssertions;
-global using Moq;
 global using Xunit;


### PR DESCRIPTION
We needed to support the use case, that we could keep listening to blob files, even if they are added during runtime. Currently, the blob configuration was always, in any case, immediately breaking the watch loop when a blob would not exist. 

With no breaking changes, it is possible when a blob file is configured as optional, then the loop keeps watching until this specific file exists. 