### PR TITLE
Improves change detection in BlobFileProviderTests

### DIFF
--- a/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
+++ b/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
@@ -86,9 +86,10 @@ public class BlobFileProviderTests
             .Returns(Response.FromValue(blobProperties, Substitute.For<Response>()));
 
         // Act
-        await tcs.Task;
+        var completedTask = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
 
         // Assert
+        Assert.Same(tcs.Task, completedTask);
         Assert.True(changeToken.HasChanged);
     }
 

--- a/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
+++ b/tests/NexxLogic.BlobConfiguration.AspNetCore.Tests/FileProvider/BlobFileProviderTests.cs
@@ -65,7 +65,7 @@ public class BlobFileProviderTests
     public async Task Watch_ShouldRaiseChange_WhenNewVersionIsAvailable()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<bool>();
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var options = new BlobConfigurationOptions
         {
             ReloadInterval = 1000


### PR DESCRIPTION
Updates `BlobFileProviderTests` to use `TaskCompletionSource` for more reliable change detection in the `Watch` test. This ensures that the test waits for the change token to be signaled before proceeding with assertions, preventing potential timing issues.